### PR TITLE
投稿した文字列を囲むデザインにする・詳細ページ削除

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -80,6 +80,7 @@ body {
 
  .balloon1-left {
     position: relative;
+    width: 700px;
     display: inline-block;
     margin: 1.5em 0 1.5em 15px;
     padding: 7px 10px;
@@ -88,6 +89,7 @@ body {
     color: #555;
     font-size: 16px;
     background: #e0edff;
+    border-radius: 5px;
   }
   
   .balloon1-left:before {

--- a/app/controllers/tsubuyakis_controller.rb
+++ b/app/controllers/tsubuyakis_controller.rb
@@ -1,6 +1,6 @@
 class TsubuyakisController < ApplicationController
 
-  before_action :set_tsubuyaki, only: [:show, :edit, :update, :destroy]
+  before_action :set_tsubuyaki, only: [:edit, :update, :destroy]
 
   def top
   end
@@ -29,9 +29,6 @@ class TsubuyakisController < ApplicationController
         render :new
       end
     end
-  end
-
-  def show
   end
 
   def edit

--- a/app/views/tsubuyakis/index.html.erb
+++ b/app/views/tsubuyakis/index.html.erb
@@ -1,18 +1,13 @@
 <h2>つぶやき一覧</h2>
 
 <p><%= notice %></p>
-
-  <table>
+  
   <% @tsubuyakis.each do |tsubuyaki| %>
-    <tr>
-      <td><%= tsubuyaki.content %></td>
-      </tr> 
-    <tr>
-      <td><%= link_to '詳細', tsubuyaki_path(tsubuyaki.id) %></td>
-      <td><%= link_to "編集", edit_tsubuyaki_path(tsubuyaki.id), data: { confirm: '本当に編集していいですか？' } %></td>
-      <td><%= link_to '削除', tsubuyaki_path(tsubuyaki.id), method: :delete, data: { confirm: '本当に削除していいですか？' } %></td>
-    </tr>
+    <div class="balloon1-left">
+      <%= tsubuyaki.content %><br>
+    </div><br>
+      <%= link_to "編集", edit_tsubuyaki_path(tsubuyaki.id), data: { confirm: '本当に編集していいですか？' } %>
+      <%= link_to '削除', tsubuyaki_path(tsubuyaki.id), method: :delete, data: { confirm: '本当に削除していいですか？' } %><br>
   <% end %>
-  </table>
 <br>
 <%= link_to '新しく投稿する', new_tsubuyaki_path %>

--- a/app/views/tsubuyakis/top.html.erb
+++ b/app/views/tsubuyakis/top.html.erb
@@ -1,3 +1,4 @@
 <h1>TOP</h1>
-
-<%= link_to "一覧画面", tsubuyakis_path %>
+<br><br>
+<%= link_to "つぶやき一覧へ", tsubuyakis_path %>
+<br><br>


### PR DESCRIPTION
小林さん

お疲れ様です。
吹き出しですが、tableを解除したら実装できました。
また、詳細ページが不要だった為削除しております。
御確認宜しくお願い致します。